### PR TITLE
Fix uploading to github.io happening before the file has actually finished being updated

### DIFF
--- a/.github/scripts/copy_raid_list_from_main_repository_to_io_repository.py
+++ b/.github/scripts/copy_raid_list_from_main_repository_to_io_repository.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 
 # Assuming that the main repository is located in ./main and the github.io repository is located in ./io:

--- a/.github/scripts/create_raid_list.py
+++ b/.github/scripts/create_raid_list.py
@@ -18,10 +18,10 @@ def itc(n): # Takes a number and writes it with comma separators.
     else:
         return "{:,}".format(int(n))
 
-base_file = "./community-gathered data/Basic raid data.csv"
-damage_file = "./community-gathered data/Base damage taken.csv"
-loot_path = "./community-gathered data/Loot tiers and drop data/"
-output_file = "./community-gathered data/raid_list.json"
+base_file = "./main/community-gathered data/Basic raid data.csv"
+damage_file = "./main/community-gathered data/Base damage taken.csv"
+loot_path = "./main/community-gathered data/Loot tiers and drop data/"
+output_file = "./main/community-gathered data/raid_list.json"
 
 default_dict = defaultdict(list)
 

--- a/.github/workflows/create_raid_list_json_and_export_it.yml
+++ b/.github/workflows/create_raid_list_json_and_export_it.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository content
         uses: actions/checkout@v4 # Checkout the repository content to github runner.
+        with:
+          path: main
       - name: Setup Python version
         uses: actions/setup-python@v5
         with:
@@ -20,9 +22,10 @@ jobs:
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip requests      
       - name: Finally run the Python file
-        run: python .github/scripts/create_raid_list.py
+        run: python main/.github/scripts/create_raid_list.py
       - name: Commit changes
         run: |
+          cd ./main/
           git config --global user.email "127596209+Matrix4348@users.noreply.github.com"
           git config --global user.name "Workflow"
           git remote set-url origin https://x-access-token:GITHUB_TOKEN@github.com/${{ github.repository }}
@@ -32,8 +35,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   add_raid_list_json_to_github_io:
-    needs:
-      - create_raid_list_json
     name: Add the raid list json to github.io
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +54,9 @@ jobs:
           python-version: 3.8 # Install the python version needed
       - name: Install Python dependencies
         run: python -m pip install --upgrade pip requests      
-      - name: Finally run the Python file
+      - name: Run the first Python script
+        run: python main/.github/scripts/create_raid_list.py
+      - name: Run the second Python script
         run: python main/.github/scripts/copy_raid_list_from_main_repository_to_io_repository.py
       - name: Commit changes
         run: |


### PR DESCRIPTION
Waiting for the first job to be finished is not enough to upload the updated file.
Because I still do not know how to commit to two different repositories in the same job (for the moment, I can only commit to the first cheched out one), I end up running create_raid_list.py twice, which is dumb.